### PR TITLE
fix: 게시글 CUD 에서 토큰값 bearer제거 코드 추가

### DIFF
--- a/controller/Cmain.js
+++ b/controller/Cmain.js
@@ -177,7 +177,8 @@ exports.postRecipe = async (req, res) => {
         }
 
         // 로그인한 사용자의 id를 토큰에서 추출
-        const token = req.headers.authorization;
+        const tokenWithBearer = req.headers.authorization;
+        const token = tokenWithBearer.split(" ")[1];
         const decodedToken = jwt.verify(token, SECRET);
         const userId = decodedToken.id;
 
@@ -228,7 +229,8 @@ exports.patchPost = async (req, res) => {
         const { title, content, img, category } = req.body;
 
         // 로그인한 사용자의 id를 토큰에서 추출
-        const token = req.headers.authorization;
+        const tokenWithBearer = req.headers.authorization;
+        const token = tokenWithBearer.split(" ")[1];
         const decodedToken = jwt.verify(token, SECRET);
         const userId = decodedToken.id;
 
@@ -277,7 +279,8 @@ exports.deletePost = async (req, res) => {
         const { postId } = req.params;
 
         // 로그인한 사용자의 id를 토큰에서 추출
-        const token = req.headers.authorization;
+        const tokenWithBearer = req.headers.authorization;
+        const token = tokenWithBearer.split(" ")[1];
         const decodedToken = jwt.verify(token, SECRET);
         const userId = decodedToken.id;
 
@@ -322,7 +325,6 @@ exports.profile = async (req, res) => {
     // res.render("profile");
     try {
         // 요청 헤더에서 토큰 추출
-        console.log("dddd", req.headers.authorization);
         const tokenWithBearer = req.headers.authorization;
         const token = tokenWithBearer.split(" ")[1];
         if (!token) {
@@ -403,7 +405,8 @@ exports.checkNickname = (req, res) => {
 
 exports.profileUpdate = async (req, res) => {
     try {
-        const token = req.headers.authorization;
+        const tokenWithBearer = req.headers.authorization;
+        const token = tokenWithBearer.split(" ")[1];
         if (!token) {
             return res.status(401).send("로그인이 필요합니다.");
         }

--- a/init.sql
+++ b/init.sql
@@ -1,4 +1,4 @@
--- Active: 1707101295615@@127.0.0.1@3306
+-- Active: 1707112054461@@127.0.0.1@3306@sesac
 show tables;
 DESC Users;
 DESC posts;


### PR DESCRIPTION
프론트에서 요청 보낼때 헤더값에 authorization에 Bearer + token값을 보내주기 때문에 서버에서 받아서 쓸때는 Bearer를 제거하고 순수 token 값만 사용하려고 
`const tokenWithBearer = req.headers.authorization;
        const token = tokenWithBearer.split(" ")[1];` 
        이 코드 추가했습니다