### PR TITLE
feat: 게시글 이미지 저장 및 프로필/게시글 이미지 경로 지정 및 게시글 작성 양식 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 package-lock.json
 .env
 *.http
+/static/profileUploads
+/static/recipeUploadImg

--- a/app.js
+++ b/app.js
@@ -1,8 +1,21 @@
 const express = require("express");
 const path = require("path");
+const fs = require("fs");
 const db = require("./models");
 const app = express();
 const PORT = 8080;
+
+// 프로필 이미지를 저장할 디렉토리
+const profileDir = path.join(__dirname, "./static/profileUploads");
+if (!fs.existsSync(profileDir)) {
+    fs.mkdirSync(profileDir, { recursive: true });
+}
+
+// 게시글 이미지를 저장할 디렉토리
+const recipeDir = path.join(__dirname, "./static/recipeUploadImg");
+if (!fs.existsSync(recipeDir)) {
+    fs.mkdirSync(recipeDir, { recursive: true });
+}
 
 app.set("views", path.join(__dirname, "views"));
 app.set("view engine", "ejs");

--- a/controller/Cmain.js
+++ b/controller/Cmain.js
@@ -4,31 +4,55 @@ const SECRET = "DWB0jOga2jrAozUXUsLCQ1e4EeeQH8"; //랜덤문자열 env관리 예
 const bcrypt = require("bcrypt");
 const path = require("path");
 const multer = require("multer");
-const uploadDetail = multer({
+
+// 프로필 이미지 업로드 multer
+const profileUpload = multer({
     storage: multer.diskStorage({
-        // 저장할 경로 profileUploads 폴더
         destination(req, file, done) {
-            done(null, "profileUploads/");
+            done(null, path.join(__dirname, "../static/profileUploads/")); // 프로필 이미지를 저장할 디렉토리
         },
         filename(req, file, done) {
-            // 파일 확장자 추출
             const ext = path.extname(file.originalname);
-            // 파일 이름을 원본 파일 이름의 베이스 이름, 현재 날짜의 타임스탬프, 확장자로
             done(null, path.basename(file.originalname, ext) + Date.now() + ext);
         },
     }),
-    // 파일 크기 제한 설정 (5MB)
     limits: { fileSize: 5 * 1024 * 1024 },
 });
-
-exports.profileUpload = (req, res) => {
+// 프로필 이미지 업로드
+exports.uploadProfileImg = (req, res) => {
     // "userfile"은 파일 업로드 필드의 name과 일치시켜야함
     console.log(req.file);
     console.log(req.body);
-    res.send("업로드 완료");
+    res.send("프로필 이미지 업로드 완료");
+};
+
+// 게시글 이미지 업로드 multer
+const recipeUpload = multer({
+    storage: multer.diskStorage({
+        destination(req, file, done) {
+            done(null, path.join(__dirname, "../static/recipeUploadImg/")); // 게시글 이미지를 저장할 디렉토리
+        },
+        filename(req, file, done) {
+            const ext = path.extname(file.originalname);
+            done(null, path.basename(file.originalname, ext) + Date.now() + ext);
+        },
+    }),
+    limits: { fileSize: 5 * 1024 * 1024 },
+});
+// 게시글 이미지 업로드
+exports.uploadRecipeImage = (req, res) => {
+    console.log(req.files);
+    console.log(req.body);
+    if (req.files.length > 0) {
+        var url = path.join("/static/recipeUploadImg/", req.files[0].filename);
+        res.send({ message: "게시글 이미지 업로드 완료", url: url });
+    } else {
+        res.status(400).send({ error: "No file was uploaded." });
+    }
 };
 // routes/index.js에서 사용할 수 있게 내보내기
-exports.uploadDetail = uploadDetail;
+exports.profileUpload = profileUpload;
+exports.recipeUpload = recipeUpload; // 게시글 이미지 업로드를 위한 `multer` 인스턴스 내보내기
 
 //암호화, 비교 함수
 const saltRounds = 10;
@@ -204,7 +228,7 @@ exports.getPosts = (req, res) => {
 // 게시글 작성
 exports.postRecipe = async (req, res) => {
     try {
-        const { title, content, img, category } = req.body;
+        const { title, content, imgURLs, category } = req.body;
         // 제목, 내용, 카테고리 유효성 검사
         if (!title || !content || !category) {
             return res.status(400).json({ error: "제목, 내용, 카테고리는 필수입니다." });
@@ -215,6 +239,7 @@ exports.postRecipe = async (req, res) => {
         const token = tokenWithBearer.split(" ")[1];
         const decodedToken = jwt.verify(token, SECRET);
         const userId = decodedToken.id;
+        const imgURLsString = JSON.stringify(imgURLs);
 
         const newRecipe = await models.Posts.create({
             title,
@@ -230,9 +255,10 @@ exports.postRecipe = async (req, res) => {
         if (err.name === "JsonWebTokenError") {
             return res.status(401).json({ error: "로그인이 필요합니다." });
         }
-        res.status(500).send("서버 에러", err);
+        res.status(500).send({ message: "서버 에러", error: err });
     }
 };
+
 //단일 게시글 조회
 exports.getPostDetail = async (req, res) => {
     try {

--- a/init.sql
+++ b/init.sql
@@ -1,4 +1,4 @@
--- Active: 1707101290768@@127.0.0.1@3306@sesac
+-- Active: 1707112054461@@127.0.0.1@3306@sesac
 show tables;
 DESC Users;
 DESC posts;
@@ -19,3 +19,5 @@ VALUES (NULL,"jisu4", "ㅋㅋㅋㅋㅋㅋㅋㅋ",NULL,"채식",NOW(),NOW(), 4);
 SELECT * from bookmarks;
 INSERT into bookmarks
 VALUES(NULL, Now(),now(),10,2)
+
+select img from `Posts` WHERE postId=23;

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,7 +2,8 @@ const express = require("express");
 const router = express.Router();
 const controller = require("../controller/Cmain");
 // multer - Cmain에서 profileUpload 미들웨어와 uploadDetail 핸들러 가져오기
-const { profileUpload, uploadDetail } = require("../controller/Cmain");
+const { profileUpload, uploadProfileImg } = require("../controller/Cmain");
+const { recipeUpload, uploadRecipeImage } = require("../controller/Cmain"); // `recipeUpload`와 `uploadImage` 가져오기
 
 // const app = require("../app");
 // router작성
@@ -32,8 +33,12 @@ router.patch("/profileUpdate/:userId", controller.profileUpdate);
 router.delete("/profile/:userId", controller.profileDelete);
 
 // multer 설정
+// 프로필 이미지 업로드
 // "userfile"은 파일 업로드 필드의 name과 일치시켜야 함
-router.post("/profileUpload", uploadDetail.single("userfile"), profileUpload);
+router.post("/profileUpload", profileUpload.single("userfile"), uploadProfileImg);
+// 게시글 이미지 업로드 - 한개의 input에 여러 파일 업로드
+router.post("/recipeUploadImg", recipeUpload.array("file"), uploadRecipeImage);
+
 // 북마크 추가
 router.post("/bookmarkInsert/:postId", controller.bookmarkInsert);
 // 북마크 조회 - 프로필 페이지에서 북마크 목록 조회

--- a/views/creatRecipeForm.ejs
+++ b/views/creatRecipeForm.ejs
@@ -23,20 +23,95 @@
         <br />
 
         <script>
+            var notice_form = `
+                <h4> 양식에 맞게 레시피를 작성해 주세요.</h4>
+                <p style="color: gray;">⚠️ 이미지는 복사, 붙여넣기 해서 첨부해 주세요.</p>
+                `;
+
+            var default_form = `
+                ${notice_form}
+                <br />
+                <p><strong> - 요리명 : </strong></p>
+                <br />
+                <p><strong> - 재료 : </strong></p>
+                <br />
+                <p><strong> - 조리 순서 : </strong></p>
+                <br />
+                `;
             $(document).ready(function () {
+                var imgURLs = []; // 이미지 URL들을 저장할 배열
+
+                function uploadImage(file) {
+                    var data = new FormData();
+                    data.append("file", file);
+                    axios({
+                        url: "/recipeUploadImg",
+                        method: "POST",
+                        data: data,
+                        headers: {
+                            "Content-Type": "multipart/form-data",
+                        },
+                    }).then(function (response) {
+                        // 이미지 URL을 에디터에 삽입
+                        $("#summernote").summernote("insertImage", response.data.url);
+                        // 전역 변수에 이미지 URL을 저장
+                        // 배열에 이미지 URL을 추가
+                        imgURLs.push(response.data.url);
+                        localStorage.setItem("imgURLs", JSON.stringify(imgURLs));
+                    });
+                }
+
                 $("#summernote").summernote({
                     placeholder: "- 나만의 레시피를 작성해 주세요",
                     tabsize: 2,
                     height: 740,
+                    toolbar: [
+                        ["style", ["bold", "italic", "underline", "clear"]],
+                        ["font", ["strikethrough", "superscript", "subscript"]],
+                        ["fontsize", ["fontsize"]],
+                        ["color", ["color"]],
+                        ["para", ["ul", "ol", "paragraph"]],
+                        ["height", ["height"]],
+                        ["insert", ["link"]],
+                        ["view", ["fullscreen", "codeview", "help"]],
+                    ],
+                    callbacks: {
+                        onFocus: function () {
+                            // 에디터가 비어 있을 때만 기본 양식을 설정
+                            if ($("#summernote").summernote("isEmpty")) {
+                                $("#summernote").summernote("code", default_form);
+                            }
+                        },
+                        onImageUpload: function (files) {
+                            uploadImage(files[0]);
+                        },
+                        onPaste: function (e) {
+                            var clipboardData = e.originalEvent.clipboardData;
+                            if (
+                                clipboardData &&
+                                clipboardData.items &&
+                                clipboardData.items.length
+                            ) {
+                                var item = clipboardData.items[0];
+                                if (item.kind === "file" && item.type.indexOf("image/") !== -1) {
+                                    e.preventDefault();
+                                    uploadImage(item.getAsFile());
+                                }
+                            }
+                        },
+                    },
                 });
             });
-        </script>
-        <script>
+
             function recipeSummit() {
                 var title = $("#title").val();
                 var content = $("#summernote").summernote("code"); // 에디터의 내용을 HTML 문자열로 가져옴
+                console.log("1", content);
+                content = content.replace(notice_form, "");
+                console.log("2", content);
                 var category = $("#category").val();
                 var accessToken = localStorage.getItem("user");
+                var imgURLs = JSON.parse(localStorage.getItem("imgURLs")); // imgURLs를 가져옴
 
                 axios({
                     method: "post",
@@ -48,6 +123,7 @@
                     data: {
                         title: title,
                         content: content,
+                        imgURLs: imgURLs, // imgURLs를 data에 추가
                         category: category,
                     },
                 })


### PR DESCRIPTION
1.  프로필 이미지 경로 폴더랑 게시글 이미지 경로 폴더랑 구분해서 생성되게끔 했습니다.
2.  게시글 작성 시 양식이 띄워지게끔 했어요
3. 게시글 작성 시 이미지 넣는 법은 파일 첨부 버튼으로 올리지 말고 드래그 앤드롭이나 이미지 복붙으로 해야 서버에 올라갑니다.  그래서 서머노트 텍스트 편집기 툴바에서 이미지 첨부하는 기능 아예 뺏어요, 양식에도 적어놨어요
