### PR TITLE
fix:DB북마크연관관계 수정 및 북마크 컨트롤러 CRD 수정 및 timestamps - 한국시간으로 설정

### DIFF
--- a/controller/Cmain.js
+++ b/controller/Cmain.js
@@ -245,7 +245,7 @@ exports.postRecipe = async (req, res) => {
         const newRecipe = await models.Posts.create({
             title,
             content,
-            img: null,
+            img: imgURLsString,
             category,
             id: userId,
         });
@@ -284,8 +284,10 @@ exports.getPostDetail = async (req, res) => {
         const year = date.getFullYear();
         const month = (date.getMonth() + 1).toString().padStart(2, "0");
         const day = date.getDate().toString().padStart(2, "0");
+        const hour = date.getHours().toString().padStart(2, "0");
+        const minute = date.getMinutes().toString().padStart(2, "0");
 
-        const formattedDate = `${year}-${month}-${day}`;
+        const formattedDate = `${year}-${month}-${day} ${hour}:${minute}`; // 시간과 분을 추가합니다.
         console.log(formattedDate);
 
         // 게시글이 존재하지 않는 경우
@@ -602,10 +604,14 @@ exports.bookmarkInsert = async (req, res) => {
         }
         res.send({ msg, result });
     } catch (e) {
-        console.log("error발생", e);
-        // return res.status(500).send("server error");
-        console.log("토큰이 만료되었습니다");
-        res.send("다시 로그인해주세요");
+        console.error("북마크 추가 중 에러 발생", err);
+        // 토큰 만료 외의 에러 메시지 전달
+        if (e instanceof jwt.TokenExpiredError) {
+            console.log("토큰이 만료되었습니다");
+            res.send("다시 로그인해주세요");
+        } else {
+            res.send({ message: "에러 발생", error: err });
+        }
     }
 };
 // 내 북마크 목록 전체 조회 /profile/:userId/bookmarks
@@ -625,15 +631,20 @@ exports.getAllBookMarks = async (req, res) => {
         const user = await models.Users.findByPk(userId, {
             include: [
                 {
-                    model: models.Posts,
-                    as: "bookmarkedPosts", // 별칭을 'bookmarkedPosts'로 설정합니다.
-                    through: { attributes: ["createdAt"] }, // // Bookmarks 테이블의 타임스탬프 정보
-                    attributes: ["postId", "title"], // 필요한 필드만 선택하여 가져옵니다.
+                    model: models.Bookmarks,
+                    attributes: ["createdAt"], // Bookmarks 테이블의 타임스탬프 정보
                     include: [
                         {
-                            model: models.Users,
-                            as: "author", // 별칭을 'author'로 설정합니다.
-                            attributes: ["userName"], // 필요한 필드만 선택하여 가져옵니다.
+                            model: models.Posts,
+                            as: "post", // 별칭을 'post'로 설정합니다.
+                            attributes: ["postId", "title"], // 필요한 필드만 선택하여 가져옵니다.
+                            include: [
+                                {
+                                    model: models.Users,
+                                    as: "author", // 별칭을 'author'로 설정합니다.
+                                    attributes: ["userName"], // 필요한 필드만 선택하여 가져옵니다.
+                                },
+                            ],
                         },
                     ],
                 },
@@ -644,18 +655,23 @@ exports.getAllBookMarks = async (req, res) => {
             return res.status(404).json({ message: "회원을 찾을 수 없습니다." });
         }
 
-        const bookmarks = user.bookmarkedPosts.map((post) => ({
-            postId: post.postId,
-            title: post.title,
-            authorName: post.author.userName, // 'author' 별칭을 사용하여 접근합니다.
-            bookmarkCreatedAt: post.Bookmarks.createdAt, // Bookmarks 테이블의 createdAt 정보
+        const bookmarks = user.Bookmarks.map((bookmark) => ({
+            postId: bookmark.post.postId,
+            title: bookmark.post.title,
+            authorName: bookmark.post.author.userName, // 'author' 별칭을 사용하여 접근합니다.
+            bookmarkCreatedAt: bookmark.createdAt, // Bookmarks 테이블의 createdAt 정보
         }));
 
         return res.status(200).json(bookmarks);
     } catch (err) {
         console.error("북마크 목록 조회 중 에러 발생", err);
-        res.send({ message: "에러 발생", error: err });
-        // 어떤 에러 인지 확인 해야함!! 토큰이 만료되었는지, 시퀄라이즈 에러인지 여러 변수가 많음
+        // 토큰 만료 외의 에러 메시지 전달
+        if (err instanceof jwt.TokenExpiredError) {
+            console.log("토큰이 만료되었습니다");
+            res.send("다시 로그인해주세요");
+        } else {
+            res.send({ message: "에러 발생", error: err });
+        }
     }
 };
 
@@ -684,13 +700,19 @@ exports.bookmarkDelete = async (req, res) => {
             return res.status(404).json({ error: "북마크가 없습니다." });
         }
         const isDeleted = await models.Bookmarks.destroy({
-            where: { postId: postId },
+            where: { postId: postId, id: userId }, // userId 추가 => 현재 로그인한 사용자만 자신의 북마크를 삭제
         });
         if (isDeleted) {
             res.send({ msg: "북마크가 삭제되었습니다." });
         }
     } catch (err) {
-        console.error("오류 상세 정보:", err);
-        return res.status(500).send("서버 에러, 상세 정보를 확인하세요.");
+        console.error("북마크 삭제 중 에러 발생", err);
+        // 토큰 만료 외의 에러 메시지 전달
+        if (err instanceof jwt.TokenExpiredError) {
+            console.log("토큰이 만료되었습니다");
+            res.send("다시 로그인해주세요");
+        } else {
+            res.send({ message: "에러 발생", error: err });
+        }
     }
 };

--- a/init.sql
+++ b/init.sql
@@ -1,3 +1,4 @@
+-- Active: 1707112054461@@127.0.0.1@3306@sesac
 
 show tables;
 DESC Users;

--- a/models/Posts.js
+++ b/models/Posts.js
@@ -17,7 +17,7 @@ const Posts = function (Sequelize, DataTypes) {
                 allowNull: false,
             },
             img: {
-                type: DataTypes.STRING(100),
+                type: DataTypes.TEXT,
                 allowNull: true,
             },
             category: {

--- a/models/Users.js
+++ b/models/Users.js
@@ -20,6 +20,10 @@ const Users = function (Sequelize, DataTypes) {
                 type: DataTypes.STRING(255),
                 allowNull: false,
             },
+            img: {
+                type: DataTypes.TEXT,
+                allowNull: true,
+            },
         },
         {
             timestamps: true,

--- a/models/index.js
+++ b/models/index.js
@@ -12,6 +12,8 @@ if (process.env.NODE_ENV) {
 }
 const db = {};
 
+config.timezone = "+09:00"; // 한국 시간으로 설정, 현재는 UTC 시간으로 설정되어 있었음 한국이랑 9시간 차이
+
 const sequelize = new Sequelize(config.database, config.username, config.password, config);
 
 // (2) 모델 불러오기, sequelize 인스턴스와 Sequelize 모듈을 전달
@@ -33,19 +35,33 @@ Posts.belongsTo(Users, {
     as: "author", // 별칭을 'author'로 설정합니다.
 });
 
-Users.belongsToMany(Posts, {
-    through: Bookmarks,
+// (allie 추가) Users와 Boookmarks는 1:N 관계
+// 하나의 사용자는 여러 개의 북마크를 가지고 있을 수 있음
+Users.hasMany(Bookmarks, {
+    foreignKey: "id", // bookmarks에서 사용할 컬럼이름 (userId 로 이름을 지어주면 좋겠지만 이미 id 라고 사용하는 곳이 많을 것이기 때문에 id로 사용)
+    sourceKey: "id", // users table에서 참조할 컬럼
+    as: "bookmarks", // 별칭을 'bookmarks'로 설정합니다.
+});
+
+Bookmarks.belongsTo(Users, {
     foreignKey: "id",
-    onUpdate: "CASCADE",
-    onDelete: "CASCADE",
-    as: "bookmarkedPosts", // 별칭을 'bookmarkedPosts'로 설정합니다.
+    targetKey: "id",
 });
-Posts.belongsToMany(Users, {
-    through: Bookmarks,
+
+// (allie 추가) Posts와 Bookmarks는 1:N관계
+// 하나의 포스트는 여러 개의 북마크를 가지고 있을 수 있음
+Posts.hasMany(Bookmarks, {
     foreignKey: "postId",
-    onUpdate: "CASCADE",
-    onDelete: "CASCADE",
+    sourceKey: "postId", // posts table에서 참조할 컬럼
+    as: "bookmarks", // 별칭을 'bookmarks'로 설정합니다.
 });
+
+Bookmarks.belongsTo(Posts, {
+    foreignKey: "postId",
+    targetKey: "postId", // posts table에서 참조할 컬럼
+    as: "post", // 별칭을 'post'로 설정합니다.
+});
+
 Users.belongsToMany(Users, {
     foreignKey: "followingId",
     as: "Followers",

--- a/views/join.ejs
+++ b/views/join.ejs
@@ -229,6 +229,7 @@
                                             .then((data) => {
                                                 if (data.statusCode === 200) {
                                                     alert("가입이 완료되었습니다!");
+                                                    window.location.href = "/login";
                                                 } else {
                                                     alert(
                                                         "가입에 실패했습니다. 다시 시도해주세요."


### PR DESCRIPTION
1. 유저 - 북마크 / 포스트 - 북마크 연관 관계 설정 다시 했습니다. 별칭도 각각 달아줬어요!
다시 풀 받으실때 app.js 시퀄라이즈 sync({ force: false }) 이 부분 true로 바꾼 다음에 서버 실행 시켜서 db 새로 만든 다음 다시 false로 바꿔주세요!

2.  북마크 추가, 조회, 삭제 모두 연관관계에 맞게끔 수정했어요 -> 북마크 삭제할때 .destroy 할때 where문에 id:userId도 추가햇습니다. 저 조건 없으면 그 포스트아이디를 가지고 있는 모든 북마크가 지워진대요ㅠ

3. 타임스탬프 시간 보니까 현재 한국 시간이 아니라 UTC 시간으로 되어있더라구요 그래서 시간도 한국시간에 맞게 9시간 추가하는 코드 추가했습니다. 그래서 작성일에 시간 분 까지 나타나게끔 했습니다.

4. 그리고 유저 프로필에 이미지 업로드 해야해서 user 테이블에 img 속성도 추가했습니다.

5. 포스트 테이블과 유저 테이블의 img 속성에는 이미지가 올라간 서버 지정 경로의 값을 텍스트로 넣어두었습니다. 그래서 img 속성의 타입은 TEXT로 바꿨어요! 길게 해야한다고 하더라구요!